### PR TITLE
Fixes applied from lab setup at SIB/UNIL

### DIFF
--- a/a-seed-from-nothing.sh
+++ b/a-seed-from-nothing.sh
@@ -103,7 +103,7 @@ cd ~/kayobe
 ./dev/install-dev.sh
 
 # Enable OVN flags
-if $ENABLE_OVN
+if [[ "$ENABLE_OVN" = "true" ]]
 then
     cat <<EOF | sudo tee config/src/kayobe-config/etc/kayobe/aufn-ovn.yml
 neutron_plugin_agent: "ovn"
@@ -117,6 +117,8 @@ EOF
 kolla_enable_ovn: yes
 EOF
     cat <<EOF | sudo tee -a config/src/kayobe-config/etc/kayobe/neutron.yml
+kolla_neutron_ml2_mechanism_drivers:
+  - ovn
 kolla_neutron_ml2_type_drivers:
   - geneve
   - vlan
@@ -125,6 +127,11 @@ kolla_neutron_ml2_tenant_network_types:
   - geneve
   - vlan
   - flat
+EOF
+    cat <<EOF | sudo tee -a config/src/kayobe-config/etc/kayobe/kolla/globals.yml
+# Enable OVN driver integration
+neutron_plugin_agent: "ovn"
+neutron_ovn_distributed_fip: "yes"
 EOF
 fi
 

--- a/openstack-device.tf
+++ b/openstack-device.tf
@@ -73,7 +73,7 @@ resource "openstack_compute_instance_v2" "registry" {
 
 resource "openstack_compute_floatingip_v2" "registry" {
   count = var.allocate_floating_ips ? 1 : 0
-  pool = "external"
+  pool = var.floating_ip_network
 }
 
 resource "openstack_compute_floatingip_associate_v2" "registry" {
@@ -143,7 +143,7 @@ resource "openstack_compute_instance_v2" "lab" {
 
 resource "openstack_compute_floatingip_v2" "lab" {
   count = var.allocate_floating_ips ? var.lab_count : 0
-  pool = "external"
+  pool = var.floating_ip_network
 }
 
 resource "openstack_compute_floatingip_associate_v2" "lab" {

--- a/vars.tf
+++ b/vars.tf
@@ -64,6 +64,11 @@ variable "allocate_floating_ips" {
   default     = "false"
 }
 
+variable "floating_ip_network" {
+  description = "Name of the external network from which to allocate FIPs"
+  default = "external"
+}
+
 # Remember to set a floating IP if you're using a bastion
 variable "create_bastion" {
   description = "Whether or not to create a bastion instance"


### PR DESCRIPTION
- Terraform for floating IPs needs a parameterised external network name
- Flag for enabling OVN needs an exact string comparison, was true on any value
- More parameters for OVN configuration