### PR TITLE
Remove unused OVN configuration settings

### DIFF
--- a/a-seed-from-nothing.sh
+++ b/a-seed-from-nothing.sh
@@ -105,10 +105,6 @@ cd ~/kayobe
 # Enable OVN flags
 if $ENABLE_OVN
 then
-    cat <<EOF | sudo tee config/src/kayobe-config/etc/kayobe/aufn-ovn.yml
-neutron_plugin_agent: "ovn"
-neutron_ovn_dhcp_agent: "yes"
-EOF
     cat <<EOF | sudo tee -a config/src/kayobe-config/etc/kayobe/bifrost.yml
 kolla_bifrost_extra_kernel_options:
   - "console=ttyS0"


### PR DESCRIPTION
The neutron_plugin_agent variable is set to ovn automatically by Kayobe when OVN is enabled. Also remove neutron_ovn_dhcp_agent which is not necessary for the training lab.

Both settings were ignored anyway because they should have been in etc/kayobe/kolla/globals.yml.