### PR TITLE
feat: optionally create A records for labs

### DIFF
--- a/openstack-device.tf
+++ b/openstack-device.tf
@@ -169,8 +169,6 @@ resource "openstack_dns_recordset_v2" "lab_dns" {
   type        = "A"
   ttl         = 300
   records     = [openstack_compute_instance_v2.lab[count.index].network[0].fixed_ip_v4]
-
-  depends_on = [openstack_compute_instance_v2.lab]
 }
 
 resource "openstack_compute_instance_v2" "lab" {

--- a/openstack-device.tf
+++ b/openstack-device.tf
@@ -157,6 +157,22 @@ resource "openstack_compute_secgroup_v2" "AUFN" {
   }
 }
 
+data "openstack_dns_zone_v2" "lab_zone" {
+  count = var.dns_zone_name != null ? 1 : 0
+  name  = var.dns_zone_name
+}
+
+resource "openstack_dns_recordset_v2" "lab_dns" {
+  count       = var.dns_zone_name != null ? var.lab_count : 0
+  zone_id     = data.openstack_dns_zone_v2.lab_zone[0].id
+  name        = format("%s-lab-%02d.%s", var.lab_prefix, count.index, var.dns_zone_name)
+  type        = "A"
+  ttl         = 300
+  records     = [openstack_compute_instance_v2.lab[count.index].network[0].fixed_ip_v4]
+
+  depends_on = [openstack_compute_instance_v2.lab]
+}
+
 resource "openstack_compute_instance_v2" "lab" {
 
   count           = var.lab_count

--- a/vars.tf
+++ b/vars.tf
@@ -79,3 +79,10 @@ variable "bastion_floating_ip" {
   description = "Bastion floating IP"
   default     = "0.0.0.0"
 }
+
+variable "dns_zone_name" {
+  description = "The name of the DNS zone to use for creating DNS records. Leave empty or null to skip DNS record creation."
+  type        = string
+  nullable    = true
+  default     = null
+}

--- a/vars.tf
+++ b/vars.tf
@@ -81,7 +81,7 @@ variable "bastion_floating_ip" {
 }
 
 variable "dns_zone_name" {
-  description = "The name of the DNS zone to use for creating DNS records. Leave empty or null to skip DNS record creation."
+  description = "The name of the DNS zone to use for creating DNS records. Leave null to skip DNS record creation."
   type        = string
   nullable    = true
   default     = null


### PR DESCRIPTION
Lab instances may have their fixed IPv4 address used for DNS A record within Designate. Minor change that improves accessing and managing lab instances.