### PR TITLE
Pin Terraform provider Openstack version 

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -11,6 +11,7 @@ terraform {
     }
     openstack = {
       source = "terraform-provider-openstack/openstack"
+      version = "2.1.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
As seen in these [Terraform change logs](https://github.com/terraform-provider-openstack/terraform-provider-openstack/blob/main/CHANGELOG.md#300--25-september-2024-) a load of deprecated resources have been removed which now breaks the deployment. 

Thanks @jackhodgkiss for helping me find this!