### PR TITLE
Remove suggestion to change user password

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ SSH in to your lab instance by running and entering the provided password:
 
     ssh lab@<lab-ip-address> -o PreferredAuthentications=password
 
-The default password is the id of the lab instance. As such, it is recommended
-that you run `passwd` immediately to change the default password.
+The default password is the UUID of the lab instance.
 
 ## Nested virtualisation
 

--- a/setup-user.sh
+++ b/setup-user.sh
@@ -22,10 +22,6 @@ cat <<EOF | sudo tee /etc/motd
 
 Welcome to the Kayobe Lab!
 
-Immediately change the default password.
-
-    passwd
-
 Optionally, attach to a tmux session in case the connection drops:
 
     tmux


### PR DESCRIPTION
This continually trips us up during training workshops, with users changing their password and not being able to access their instances. There's nothing secure on these lab machines, and the existing password provides plenty of security.