### PR TITLE
add module.path to be able to find file

### DIFF
--- a/openstack-device.tf
+++ b/openstack-device.tf
@@ -10,7 +10,6 @@ resource "openstack_compute_instance_v2" "bastion" {
   flavor_name     = var.bastion_flavor
   key_pair        = openstack_compute_keypair_v2.ufn_lab_key.name
   security_groups = ["default"]
-
   network {
     name = var.lab_net_ipv4
   }

--- a/openstack-device.tf
+++ b/openstack-device.tf
@@ -10,6 +10,7 @@ resource "openstack_compute_instance_v2" "bastion" {
   flavor_name     = var.bastion_flavor
   key_pair        = openstack_compute_keypair_v2.ufn_lab_key.name
   security_groups = ["default"]
+
   network {
     name = var.lab_net_ipv4
   }
@@ -95,7 +96,7 @@ resource "null_resource" "registry" {
   }
 
   triggers = {
-    pull_retag_push_images = file("pull-retag-push-images.sh")
+    pull_retag_push_images = file("${path.module}/pull-retag-push-images.sh")
   }
 
   provisioner "file" {


### PR DESCRIPTION
Without this terraform cant find the script in order to scp it to the registry and wont warn/error that it couldnt. This causes the registry to never actually be deployed.